### PR TITLE
Fix typo in module documentation

### DIFF
--- a/plugins/modules/nxos_banner.py
+++ b/plugins/modules/nxos_banner.py
@@ -30,7 +30,7 @@ author: Trishna Guha (@trishnaguha)
 short_description: Manage multiline banners on Cisco NXOS devices
 description:
 - This will configure both exec and motd banners on remote devices running Cisco NXOS.
-  It allows playbooks to add or remote banner text from the active running configuration.
+  It allows playbooks to add or remove banner text from the active running configuration.
 options:
   banner:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an apparent typo in the documentation that explains what the module does.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Changes `nxos/plugins/modules/nxos_banner.py` and replace the word `remote` with `remove`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

This change does not add or change any current functionality.  It replaces a word to make the documentation a bit more clear regarding what it actually does.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
description:
- This will configure both exec and motd banners on remote devices running Cisco NXOS.
  It allows playbooks to add or remote banner text from the active running configuration.

```
After:
```
description:
- This will configure both exec and motd banners on remote devices running Cisco NXOS.
  It allows playbooks to add or remove banner text from the active running configuration.
```